### PR TITLE
Update content-filters.php

### DIFF
--- a/includes/content-filters.php
+++ b/includes/content-filters.php
@@ -786,6 +786,7 @@ function badgeos_get_current_page_post_id() {
  * @param $link
  * @return string
  */
+/*
 function badgeos_hide_next_hidden_achievement_link($link) {
 
 	if($link) {
@@ -802,13 +803,15 @@ function badgeos_hide_next_hidden_achievement_link($link) {
 
 }
 add_filter('next_post_link', 'badgeos_hide_next_hidden_achievement_link');
-
+*/
 /**
  * Hide the hidden achievement post link from previous post link
  *
  * @param $link
  * @return string
  */
+
+/*
 function badgeos_hide_previous_hidden_achievement_link($link) {
 
 
@@ -827,7 +830,7 @@ function badgeos_hide_previous_hidden_achievement_link($link) {
 }
 
 add_filter('previous_post_link', 'badgeos_hide_previous_hidden_achievement_link');
-
+*/
 
 /*
  * Get post link without hidden achievement link


### PR DESCRIPTION
I have an issue with these functions that hide "the hidden achievement post link from next post link and the previous post link".

I had to comment them in my site, because it has a conflict with the_post_navigation.

Any ideas on how to fix it without commenting these lines? I don't know if commenting will bring new issues later on on my website.